### PR TITLE
Add mergesort and two more replace stubs

### DIFF
--- a/src/listwiz/inspect.py
+++ b/src/listwiz/inspect.py
@@ -33,5 +33,5 @@ def longest_decreasing_streak(l):
 
 
 def most_common_element(l):
-    # Find the mmost common element in the list
+    # Find the most common element in the list
     raise NotImplementedError

--- a/src/listwiz/replace.py
+++ b/src/listwiz/replace.py
@@ -1,0 +1,39 @@
+
+def replaced_element(l, element, replacement):
+    raise NotImplementedError
+
+
+def replace_sublist(l, sublist, replacement):
+    """Naive function to replace a sublist with a replacement list.
+
+    Parameters
+    ----------
+    l : list
+        List to replace all occurances of sublist.
+    sublist : list
+        A (shorter) list to search for.
+    replacement : list
+        A new list to insert instead of sublist.
+
+    Examples
+    --------
+    >>> from listwiz.replace import replace_sublist
+
+    Replace any occurance of ``[2, 3]`` with ``[3, 2]``
+
+    >>> replace_sublist([1, 2, 3, 4], [2, 3], [3, 2])
+    [1, 3, 2, 4]
+
+    """
+    len_sublist = len(sublist)
+    result = l[:]  # copy the input list
+
+    i = 0
+    while i < len(result):
+        if result[i:i+len_sublist] == sublist:
+            result[i:i+len_sublist] = replacement
+            i += len_sublist
+        else:
+            i += 1
+
+    return result

--- a/src/listwiz/replace.py
+++ b/src/listwiz/replace.py
@@ -1,5 +1,6 @@
 
-def replaced_element(l, element, replacement):
+def replaced_elements(l, mapping):
+    # See issue #12
     raise NotImplementedError
 
 

--- a/src/listwiz/sorting.py
+++ b/src/listwiz/sorting.py
@@ -1,7 +1,6 @@
 
 def merge_sort(l):
-    """Use the merge sort algorithm to sort the list
-    elements
+    """Use the merge sort algorithm to sort the list elements.
 
     Parameters
     ----------
@@ -12,7 +11,30 @@ def merge_sort(l):
     -------
     sorted_list
     """
-    raise NotImplementedError
+    # If there is a single item, the list is already sorted, return.
+    if len(l) == 1:
+        return l
+
+    split = len(l) // 2
+    # Split and sort each part by calling merge_sort recursively
+    part1 = merge_sort(l[:split])
+    part2 = merge_sort(l[split:])
+
+    # The result is a new list adding always the smaller items from each list
+    res = []
+    while len(part1) and len(part2):
+        if part1[0] <= part2[0]:
+            res.append(part1.pop(0))
+        else:
+            res.append(part2.pop(0))
+
+    # One of the lists is not fully consumed, add all remaining elements:
+    if len(part1):
+        res.extend(part1)
+    else:
+        res.extend(part2)
+
+    return res
 
 
 def bubble_sort(l):

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,0 +1,24 @@
+import pytest
+
+from listwiz import replace as lwr
+
+
+def test_replace_element():
+    # Stub to be replaced with actual tests when implementing the function
+    pass
+
+
+def test_replace_sublist_simple():
+    # Replace sublist does not have any test right now.
+    pass
+
+
+def test_replace_sublist_overlap():
+    # The sublist may match with overlap (e.g. if it is just [1, 1])
+    # We should add one or more test that check we replace the first occurance.
+    pass
+
+
+def test_replace_sublist_empty():
+    # This is a stub for testing the bug with empty sublists.
+    pass

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -3,19 +3,21 @@ import pytest
 from listwiz import replace as lwr
 
 
-def test_replace_element():
-    # Stub to be replaced with actual tests when implementing the function
+def test_replace_elements():
+    # Stub to be replaced with actual tests when implementing the function,
+    # see issue #12.
     pass
 
 
 def test_replace_sublist_simple():
-    # Replace sublist does not have any test right now.
+    # Replace sublist does not have any test right now. See issue #13.
     pass
 
 
 def test_replace_sublist_overlap():
     # The sublist may match with overlap (e.g. if it is just [1, 1])
     # We should add one or more test that check we replace the first occurance.
+    # See issue #13.
     pass
 
 

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -3,18 +3,28 @@ import pytest
 from listwiz import sorting as lws
 
 
-@pytest.mark.xfail(reaso="mergesort doesn't work yet!")
 def test_mergesort():
-   l = [3, 2, 1, 5, 4, 6]
-   res = lws.merge_sort(l)
-   assert res == [1, 2, 3, 4, 5, 6]
+    # Test even sized list:
+    l = [3, 2, 1, 5, 4, 6]
+    res = lws.merge_sort(l)
+    assert res == [1, 2, 3, 4, 5, 6]
+
+    # Test odd sized list:
+    l = [5, 4, 3, 2, 1]
+    res = lws.merge_sort(l)
+    assert res == [1, 2, 3, 4, 5]
 
 
-@pytest.mark.skip(reason="Just a stub, not implemented yet")
-def test_bubble_sort():
+def test_mergesort_empty():
+    # Stub for a test with empty lists
     pass
 
 
-@pytest.mark.skip(reason="Just a stub, not implemented yet")
+def test_bubble_sort():
+    # Stub for basic bubble sort tests
+    pass
+
+
 def test_selection_sort():
+    # Stub for basic selection sort tets
     pass

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -16,15 +16,15 @@ def test_mergesort():
 
 
 def test_mergesort_empty():
-    # Stub for a test with empty lists
+    # Stub for a test with empty lists, see issue #8
     pass
 
 
 def test_bubble_sort():
-    # Stub for basic bubble sort tests
+    # Stub for basic bubble sort tests, see issue #9
     pass
 
 
 def test_selection_sort():
-    # Stub for basic selection sort tets
+    # Stub for basic selection sort tests, see issue #10
     pass


### PR DESCRIPTION
Adds the mergesort implementation (with bug).

Also adds a `replace_element()` stub, and a `replace_sublist()` function that has another similar bug (empty lists fail), and no tests (we can add tests live).

(I suppose once we have flake8 some of this might complain about unused imports :)).